### PR TITLE
Remove incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # AS516x
-Arduino Library for configuring AS516x encoders
+Arduino sketch for configuring AS516x encoders


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/madhephaestus/AS516x